### PR TITLE
Replace Travis CI with GitHub Actions in instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ We currently follow (roughly) the following process:
 
   CI and automated testing is important for keeping code well
   maintained. We currently make use of the
-  [Travis CI](https://travis-ci.org/) system, and we suggest that all
-  repositories added to `ocaml-community` should have Travis configs
-  added.
+  [GitHub Actions](https://docs.github.com/en/actions) system,
+  and we suggest that all repositories added to `ocaml-community`
+  have a workflow set up to build and run tests.
 
 ## The Conduct We Expect of Project Participants
 


### PR DESCRIPTION
As suggested in #41, though someone who are involved with the ocaml-comminty CI setup should take a look before merging.